### PR TITLE
Allow configuring log folder through environment

### DIFF
--- a/Plugin/sources/UnityHelpers.cpp
+++ b/Plugin/sources/UnityHelpers.cpp
@@ -7,6 +7,7 @@
 #include <windows.h>
 #endif
 //#include <gl/gl.h>
+#include <glib.h>
 
 
 
@@ -73,8 +74,9 @@ LogManager* LogManager::Instance()
 
 LogManager::LogManager()
 {
-	fileName = "GStreamerLog.txt";
-	m_logFile = fopen("GStreamerLog.txt", "w");
+    logFilePath = DetermineLogFilePath("GStreamerLog.txt");
+
+	m_logFile = fopen(logFilePath.c_str(), "w");
 	fclose(m_logFile);
 	m_logFile = 0;
 }
@@ -84,12 +86,25 @@ LogManager::~LogManager()
 }
 void LogManager::LogMessage(const std::string& msg)
 {
-	m_logFile = fopen("GStreamerLog.txt", "a");
+    m_logFile = fopen(logFilePath.c_str(), "a");
 	fprintf(m_logFile, "%s\n", msg.c_str());
 	fclose(m_logFile);
 	m_logFile = 0;
 }
 
+std::string LogManager::DetermineLogFilePath(const std::string& fileName)
+{
+    std::string logFilePathDirectory = "";
+    const gchar* environmentLogFilePath = g_getenv("GSTREAMER_UNITY_LOG_FILE_PATH");
+
+    if (environmentLogFilePath != NULL)
+    {
+        logFilePathDirectory = environmentLogFilePath;
+        logFilePathDirectory += "\\";
+    }
+
+    return logFilePathDirectory + fileName;
+}
 
 
 void CopyToTexture(const ImageInfo* src, uchar* dst,video::EPixelFormat fmt)

--- a/Plugin/sources/UnityHelpers.h
+++ b/Plugin/sources/UnityHelpers.h
@@ -41,7 +41,10 @@ extern "C" class UNITY_INTERFACE_EXPORT LogManager
 {
 	static LogManager* s_instance;;
 	FILE* m_logFile;
-	std::string fileName;
+	std::string logFilePath;
+
+	std::string DetermineLogFilePath(const std::string& fileName);
+
 public:
 	LogManager();
 	~LogManager();


### PR DESCRIPTION
This allows configuring the log folder through the environment variable `GSTREAMER_UNITY_LOG_FILE_PATH`. This allows you to do something like this in Unity:

```csharp
Environment.SetEnvironmentVariable("GSTREAMER_UNITY_LOG_FILE_PATH", Application.persistentDataPath);
```

... which can be important for protected environment such as UWP, which limit where you can write these kinds of files.

If it is not set, the current default is used (the current working directory) as fallback.

I didn't know what to do about tabs and spaces, since it appears this file is a mixed bag already :smile:.

Might help for #15.