### PR TITLE
Fix GLib errors being logged as info instead of error in logs

### DIFF
--- a/Plugin/sources/GStreamerCore.cpp
+++ b/Plugin/sources/GStreamerCore.cpp
@@ -96,7 +96,7 @@ void g_logFunction(const gchar   *log_domain,
         LogMessage(message, ELL_INFO);
     else if(log_level==G_LOG_LEVEL_WARNING)
         LogMessage(message, ELL_WARNING);
-    else if(log_level==G_LOG_LEVEL_CRITICAL || log_level==G_LOG_FLAG_FATAL)
+    else if(log_level==G_LOG_LEVEL_CRITICAL || log_level==G_LOG_FLAG_FATAL || log_level==G_LOG_LEVEL_ERROR)
         LogMessage(message, ELL_ERROR);
     else
         LogMessage(message, ELL_INFO);


### PR DESCRIPTION
`G_LOG_LEVEL_ERROR` was not being checked for, so these messages end up in the `else` branch. This confused me and made me think that some internal GStreamer errors were actually harmless, whilst they were in fact breaking.