### PR TITLE
Fix legacy for each loop failing build in conformance mode

### DIFF
--- a/Plugin/sources/UnityAudioGrabber.cpp
+++ b/Plugin/sources/UnityAudioGrabber.cpp
@@ -23,11 +23,11 @@ UnityAudioGrabber::UnityAudioGrabber()
 }
 UnityAudioGrabber::~UnityAudioGrabber()
 {
-	for each (float* v in _graveyard)
+	for (float* v : _graveyard)
 	{
 		delete[] v;
 	}
-	for each (float* v in _samples)
+	for (float* v : _samples)
 	{
 		delete[] v;
 	}


### PR DESCRIPTION
When building in conformance mode (advised for UWP), these two lines fail. This, newer, range-based for loop [is supported since C++11](https://en.cppreference.com/w/cpp/language/range-for).

Useful for #15.