### PR TITLE
Log warning when requesting unsupported color conversions

### DIFF
--- a/Plugin/includes/ImageInfo.cpp
+++ b/Plugin/includes/ImageInfo.cpp
@@ -3,7 +3,7 @@
 #include "ImageInfo.h"
 
 #include "PixelUtil.h"
-
+#include <string>
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) < (b)) ? (b) : (a))
@@ -256,7 +256,10 @@ void ImageInfo::copyCroppedFrom(const ImageInfo* src,Vector2d pos,Vector2d sz,bo
 	}
 	else
 	{
-
+		LogManager::Instance()->LogMessage(
+			"ImageInfo - WARNING: Conversion requested from pixel format " + std::to_string(src->format) + " to " +
+			std::to_string(targetFormat) + ", which is currently not supported, and was ignored."
+		);
 	}
 }
     


### PR DESCRIPTION
This seems to happen in some pipelines when you don't explicitly convert to I420, and the pipeline offers or negotiates another format, such as NV12, because I420 is not supported.

In this case, you'll need to add support for this new format, or otherwise you'll get the image data in its original format. This is fine, but at least a warning now shows up about what's happening.